### PR TITLE
fix broken links

### DIFF
--- a/pkg/observability/components/MonitorTab.vue
+++ b/pkg/observability/components/MonitorTab.vue
@@ -116,7 +116,11 @@ export default {
 
     <template #col:monitor="{row}">
       <td>
-        <a :href="`https://${url}/#/components/${encodeURIComponent(urn)}`" target="_blank">{{ row.name }}</a>
+        <a
+          :href="`https://${url}/#/components/${encodeURIComponent(urn)}`"
+          target="_blank"
+          rel="nofollow noopener noreferrer"
+        >{{ row.name }}</a>
       </td>
     </template>
 

--- a/pkg/observability/formatters/ComponentLinkedHealthState.vue
+++ b/pkg/observability/formatters/ComponentLinkedHealthState.vue
@@ -77,6 +77,7 @@ export default {
         componentIdentifier
       )}`"
       target="_blank"
+      rel="nofollow noopener noreferrer"
     >
       <HealthState :state="health" :color="color" />
     </a>

--- a/pkg/observability/l10n/en-us.yaml
+++ b/pkg/observability/l10n/en-us.yaml
@@ -44,9 +44,12 @@ observability:
     saveSuccess: Configuration saved successfully!
   clusterCard:
     clusterIs: Cluster is
-    notObserved: 'Cluster is not observed by Rancher Prime Observability. Please <a href="/c/{id}/apps/charts/chart?repo-type=cluster&repo=rancher-partner-charts&chart=stackstate-k8s-agent">install</a> the agent'
+    notObservedPrepend: 'Cluster is not observed by Rancher Prime Observability. Please '
+    notObservedInstall: 'install'
+    notObservedPostpend: 'the agent'
     connecting: "Connecting to Observability Plane..."
-    notConnected: 'Rancher Prime Observability has not been configured, please go to the <a href="/dashboard/observability/c/_/observability.rancher.io.dashboard">Rancher Prime Observability Configuration</a>'
+    notConnectedPrepend: 'Rancher Prime Observability has not been configured, please go to the'
+    notConnectedObservability: 'Rancher Prime Observability Configuration.'
     clusterHealth: "Cluster health:"
     componentsHealth: "Components health:"
     deviating: "Deviating:"

--- a/pkg/observability/types/headers.ts
+++ b/pkg/observability/types/headers.ts
@@ -5,7 +5,6 @@ export const ObservabilityHealth: TableColumn = {
   getValue: (row: any) => {
     return 'UNKNOWN';
   },
-  sort:          ['stateSort'],
   formatter:     'ComponentLinkedHealthState',
   width:         100,
   formatterOpts: { arbitrary: true }


### PR DESCRIPTION
- fix broken links on observability card in cluster explorer
- add `rel` property to links for security purpose https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener