### PR TITLE
STAC-21647 Drop upper kube-version limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rancher-extension-stackstate",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "private": true,
   "engines": {

--- a/pkg/observability/package.json
+++ b/pkg/observability/package.json
@@ -1,12 +1,13 @@
 {
   "name": "observability",
   "description": "Tech Preview - Rancher Prime Observability Extension",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "author": "SUSE",
   "private": false,
   "rancher": {
     "annotations": {
+      "catalog.cattle.io/kube-version": ">= 1.16.0-0",
       "catalog.cattle.io/rancher-version": ">= 2.9.0 < 2.10.0",
       "catalog.cattle.io/ui-extensions-version": ">= 2.0.1"
     }


### PR DESCRIPTION
Delete kube-version upper limit.

The built charts are in the [v0.5.0-beta.1](https://github.com/StackVista/rancher-extension-stackstate/tree/v0.5.0-beta.1) branch