### PR TITLE
Support suse-observability-agent

### DIFF
--- a/pkg/observability/modules/observed.ts
+++ b/pkg/observability/modules/observed.ts
@@ -5,7 +5,9 @@ export async function isStackStateObserved(
   const response = await store.dispatch(`cluster/request`, { url: `/k8s/clusters/${ clusterId }/v1/apps.deployments` });
 
   return response?.data?.filter(
-    (depl: any) => depl.metadata?.labels &&
-      depl.metadata.labels['app.kubernetes.io/name'] === 'stackstate-k8s-agent'
+    (depl: any) => depl.metadata?.labels && (
+      depl.metadata.labels['app.kubernetes.io/name'] === 'suse-observability-agent' ||
+      // backwards compatibility
+      depl.metadata.labels['app.kubernetes.io/name'] === 'stackstate-k8s-agent')
   );
 }


### PR DESCRIPTION
Because the Agent has been renamed to `suse-observability-agent` we need to update the check for the agent application name in the code.

This PR adds support for the new name, and keeps the old one intact for backwards compatibility.

Signed-off-by: Jeroen van Erp <jeroen.vanerp@suse.com>