### PR TITLE
Bump 1.0.2

### DIFF
--- a/pkg/observability/package.json
+++ b/pkg/observability/package.json
@@ -1,7 +1,7 @@
 {
   "name": "observability",
   "description": "SUSE Rancher Prime Observability Extension",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "Apache-2.0",
   "author": "SUSE",
   "private": false,


### PR DESCRIPTION
This will bump the Observability version to `1.0.2` which should contain the changes implemented by #24

Currently the Observability extension is unavailable to Rancher version `2.10.1` due to [this annotation](https://github.com/StackVista/rancher-extension-stackstate/blob/71e0ce96812a66521474b33dac21c4124676d321/index.yaml#L10). Releasing a new version would build a new chart containing the [updated annotation](https://github.com/StackVista/rancher-extension-stackstate/blob/f1941b85e80520d3507fb20a56fc5a7013b6ec9b/pkg/observability/package.json#L11).