### PR TITLE
Update product.ts to fix TS error

### DIFF
--- a/.changeset/fluffy-jokes-film.md
+++ b/.changeset/fluffy-jokes-film.md
@@ -1,0 +1,5 @@
+---
+"observability": patch
+---
+
+Drop the unsupported definition of `ProductOptions.label` field from `product.ts`.

--- a/pkg/observability/product.ts
+++ b/pkg/observability/product.ts
@@ -36,8 +36,6 @@ export function init($plugin: IPlugin, store: any) {
     // @ts-ignore -- though `svg` is not part of the interface, it does work.
     svg:  stsIcon,
     name: OBSERVABILITY_PRODUCT_NAME,
-
-    label:               store.getters['i18n/t']('observability.name'),
     inStore:             'management',
     showClusterSwitcher: true,
     to:                  {


### PR DESCRIPTION
Updates product.ts to fix TS error on https://github.com/rancher/dashboard/pull/12952 + https://github.com/rancher/dashboard/actions/runs/12506112573/job/34890542483?pr=12952

There is no `label` property on `ProductOptions` and it doesn't do anything. We should clean it up in order for the pipeline to pass