### PR TITLE
add resolution for entities package

### DIFF
--- a/.changeset/healthy-lemons-flow.md
+++ b/.changeset/healthy-lemons-flow.md
@@ -1,0 +1,7 @@
+---
+"observability": patch
+---
+
+Add resolution for `entities` package to satisfy the constraints verified with the update of Rancher Dashboard to VueJS 3.5.
+
+Fixes https://github.com/rancher/dashboard/issues/13175

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@nuxtjs/eslint-config-typescript": "6.0.1"
   },
   "resolutions": {
-    "@types/lodash": "4.14.184"
+    "@types/lodash": "4.14.184",
+    "entities": "4.5.0"
   },
   "scripts": {
     "lint": "eslint --ext .ts,.js,.vue",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8142,20 +8142,10 @@ enquirer@^2.3.5, enquirer@^2.3.6, enquirer@^2.4.1:
     ansi-colors "^4.1.1"
     strip-ansi "^6.0.1"
 
-entities@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
-  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
-
-entities@^4.5.0:
+entities@4.5.0, entities@^2.0.0, entities@^4.5.0, entities@~2.1.0:
   version "4.5.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
-
-entities@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
-  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
 error-ex@^1.3.1:
   version "1.3.2"


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/13175

Add resolution for `entities` package so that it satisfies the constraints verified with the update of Rancher Dashboard to VueJS 3.5 on https://github.com/rancher/dashboard/pull/13085 as we can't fix this on the shell side for now because of a bug in yarn classic.