### PR TITLE
Update MonitorTab.vue to fix problem with absence of `resource`

### DIFF
--- a/.changeset/light-guests-flow.md
+++ b/.changeset/light-guests-flow.md
@@ -1,0 +1,5 @@
+---
+"observability": patch
+---
+
+Update the MonitorTab to fetch the `resource` data if the prop data is missing (mitigates https://github.com/rancher/dashboard/issues/14321)


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/14321

- Update `MonitorTab.vue` to fix problem with absence of `resource` (this will fetch the resource instance from the store)


How can this be tested:
- do a developer load of this code https://extensions.rancher.io/extensions/next/extensions-getting-started#test-built-extension-by-doing-a-developer-load (build extension code locally, serve it then on Rancher UI do the developer load - don't forget to persist the resource).
- Test in all location where monitor tab component is loaded 


Recommendations:
- not for now, because we want to isolate the changes, but you should consider bumping the Shell version to the latest `3.0.4`
- I think you can remove https://github.com/StackVista/rancher-extension-stackstate/blob/main/pkg/observability/index.ts#L146 from the list because, afaik, there's no detail view for `management.cattle.io.cluster`